### PR TITLE
Add support for more relative URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,9 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import isRelativeUrl from 'is-relative-url'
 import mimes from 'mime/lite.js'
 import {visit} from 'unist-util-visit'
-
-const relative = /^\.{1,2}\//
 
 /**
  * Plugin to embed local images as data URIs.
@@ -20,7 +19,7 @@ export default function embedImages() {
     const base = file.dirname ? path.resolve(file.cwd, file.dirname) : file.cwd
 
     visit(tree, 'image', (node) => {
-      if (node.url && relative.test(node.url)) {
+      if (node.url && isRelativeUrl(node.url) && !node.url.startsWith('/')) {
         count++
 
         fs.readFile(path.resolve(base, node.url), 'base64', (error, data) => {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "dependencies": {
     "@types/mdast": "^3.0.0",
+    "is-relative-url": "^3.0.0",
     "mime": "^3.0.0",
     "unified": "^10.0.0",
     "unist-util-visit": "^4.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -6,13 +6,23 @@ import remarkHtml from 'remark-html'
 import remarkEmbedImages from '../index.js'
 
 test('remark-embed-images', async (t) => {
-  t.plan(6)
+  t.plan(7)
 
   t.match(
     String(
       await remark()
         .use(remarkEmbedImages)
         .process('![](./test/fixtures/foo.png)')
+    ),
+    /!\[]\(data:image\/png;base64,/,
+    'should inline images w/o file path'
+  )
+
+  t.match(
+    String(
+      await remark()
+        .use(remarkEmbedImages)
+        .process('![](test/fixtures/foo.png)')
     ),
     /!\[]\(data:image\/png;base64,/,
     'should inline images w/o file path'


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Currently relative links to images without the `./` prefix will not be embedded.

This change allows the same relative links for images as before:

```markdown
![A pink square](./foo.png)
```

and also will enable links without the prefix:

```markdown
![A pink square](foo.png)
```

<!--do not edit: pr-->
